### PR TITLE
[DICE-23] 온보딩 관련 스크린 수정 (로그인 / 회원가입 등)

### DIFF
--- a/app/(onBoarding)/_layout.tsx
+++ b/app/(onBoarding)/_layout.tsx
@@ -12,6 +12,9 @@ export default function OnBoardingLayout() {
       {/* 회원가입 */}
       <Stack.Screen name="register" options={{ headerShown: false }} />
 
+      {/* 브랜드 프로필 */}
+      <Stack.Screen name="brandProfile" options={{ headerShown: false }} />
+
       {/* 비밀번호 찾기 */}
       <Stack.Screen name="findPassword" options={{ headerShown: false }} />
     </Stack>

--- a/app/(onBoarding)/brandProfile.tsx
+++ b/app/(onBoarding)/brandProfile.tsx
@@ -1,0 +1,102 @@
+import { Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import BackHeaderComponent from '@/components/common/backHeader';
+import CTAContainer from '@/components/common/ctaContainer';
+import CustomPressable from '@/components/common/customPressable/customPressable';
+import CustomSelect from '@/components/common/customSelect';
+import CustomTextInput from '@/components/common/customTextInput';
+import HorizontalImageList from '@/components/common/imageList';
+import { ageRangeItems, genderItems } from '@/constants/filtering';
+import KeyBoardAwareProvider from '@/providers/keyBoardProvider';
+import { useSignUpStore } from '@/zustands/onBoard/store';
+
+export default function BrandProfile() {
+  const {
+    signUpStore,
+    setTargetGender,
+    setTargetAgeGroup,
+    setBrandName,
+    setBrandDescription,
+    setImageUrls,
+  } = useSignUpStore();
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <BackHeaderComponent style="WHITE" hasSafeArea={false} title="회원가입" />
+
+      <KeyBoardAwareProvider rowGap={24}>
+        <View className="gap-y-[8px] pt-[32px] pb-[8px]">
+          <Text className="H2 text-black">브랜드 프로필을 등록해주세요</Text>
+          <Text className="SUB3 text-deep_gray">
+            선택한 브랜드 타겟에 맞는 팝업 공간을 추천드려요
+          </Text>
+        </View>
+
+        <CustomSelect
+          label="브랜드 타겟 성별"
+          subLabel=" (중복 선택 가능)"
+          required={true}
+          value={signUpStore.brandProfile.targetGender}
+          setValue={setTargetGender}
+          options={genderItems}
+          wrapGap="gap-1.5"
+          padding="px-3 py-1"
+          rounded="rounded-full"
+        />
+
+        <CustomSelect
+          label="브랜드 타겟 연령대"
+          subLabel=" (중복 선택 가능)"
+          required={true}
+          value={signUpStore.brandProfile.targetAgeGroup}
+          setValue={setTargetAgeGroup}
+          options={ageRangeItems}
+          textStyle="BTN2"
+        />
+
+        <CustomTextInput
+          label="내 브랜드 이름"
+          subLabel=" (선택)"
+          value={signUpStore.brandProfile.name}
+          setValue={setBrandName}
+          placeholder="브랜드 이름을 입력해주세요"
+        />
+
+        <CustomTextInput
+          label="짧은 브랜드 소개"
+          subLabel=" (선택)"
+          value={signUpStore.brandProfile.description}
+          setValue={setBrandDescription}
+          multiline={true}
+          height="h-24"
+          placeholder="팝업 공간을 대여해주는 호스트와 신뢰할 수 있는 거래를 위해 브랜드를 1~2문장으로 짧게 설명해주세요"
+        />
+
+        <HorizontalImageList
+          label="브랜드, 상품 관련 이미지"
+          subLabel=" (최대 10장/선택)"
+          value={signUpStore.brandProfile.imageUrls}
+          setValue={setImageUrls}
+        />
+      </KeyBoardAwareProvider>
+
+      <CTAContainer extraBottom={16}>
+        <CustomPressable
+          buttonText="회원가입"
+          onPress={() => {}}
+          disabled={
+            signUpStore.brandProfile.targetGender.length === 0 ||
+            signUpStore.brandProfile.targetAgeGroup.length === 0
+          }
+          color={
+            signUpStore.brandProfile.targetGender.length === 0 ||
+            signUpStore.brandProfile.targetAgeGroup.length === 0
+              ? 'GRAY'
+              : 'BLACK'
+          }
+        />
+      </CTAContainer>
+    </SafeAreaView>
+  );
+}

--- a/app/(onBoarding)/login.tsx
+++ b/app/(onBoarding)/login.tsx
@@ -1,39 +1,29 @@
 import { useRouter } from 'expo-router';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { Pressable, Text, TouchableWithoutFeedback, View } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import { TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import XIcon from '@/assets/icons/x.svg';
-import CustomPressableComponent from '@/components/common/customPressable';
-import LoginInputControllerComponent from '@/components/onBoard/loginInputController';
+import CustomPressable from '@/components/common/customPressable/customPressable';
+import TextButton from '@/components/common/textButton';
+import LoginForm from '@/components/onBoard/login/loginForm';
 import { useLogin } from '@/hooks/auth/auth';
-import { useDomainModalStore } from '@/zustands/onBoard/store';
-
-type FormData = {
-  email: string;
-  password: string;
-};
+import KeyBoardAwareProvider from '@/providers/keyBoardProvider';
+import { LoginDto } from '@/types/auth';
 
 export default function Login() {
   const router = useRouter();
 
-  const { setIsDomainModalOpen } = useDomainModalStore();
-
-  const formFields: { name: keyof FormData; placeholder: string }[] = [
+  const formFields: { name: keyof LoginDto; placeholder: string }[] = [
     { name: 'email', placeholder: '이메일 아이디를 입력해주세요' },
     { name: 'password', placeholder: '비밀번호를 입력해주세요' },
   ];
 
-  const {
-    control,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<FormData>();
+  const { control, handleSubmit } = useForm<LoginDto>();
 
   const { mutateAsync: login } = useLogin(false);
 
-  const onSubmit: SubmitHandler<FormData> = async (data: FormData) => {
+  const onSubmit: SubmitHandler<LoginDto> = async (data: LoginDto) => {
     await login({
       email: data.email,
       password: data.password,
@@ -42,43 +32,20 @@ export default function Login() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <Pressable onPress={() => router.back()} className="self-start p-[12px] ml-[3px]">
+      <TouchableOpacity onPress={() => router.back()} className="self-start p-[12px] ml-[3px]">
         <XIcon />
-      </Pressable>
+      </TouchableOpacity>
 
-      <TouchableWithoutFeedback onPress={() => setIsDomainModalOpen(false)}>
-        <KeyboardAwareScrollView
-          contentContainerStyle={{ rowGap: 32, marginVertical: 'auto', paddingBottom: 48 }}
-          keyboardShouldPersistTaps="handled"
-          enableOnAndroid={true}
-          extraScrollHeight={20}
-        >
-          <View className="px-[20px] gap-y-[32px]">
-            <Text className="H1 text-black">로그인</Text>
-            <View className="gap-y-[12px]">
-              {formFields.map((field) => (
-                <LoginInputControllerComponent
-                  key={field.name}
-                  control={control}
-                  name={field.name}
-                  placeholder={field.placeholder}
-                />
-              ))}
-            </View>
-          </View>
+      <KeyBoardAwareProvider rowGap={32} isCenter={true}>
+        <LoginForm formFields={formFields} control={control} />
 
-          <View className="gap-y-[11px]">
-            <CustomPressableComponent
-              buttonText="로그인"
-              onPress={handleSubmit(onSubmit)}
-              disabled={false}
-            />
-            <Pressable className="self-center px-[16px] py-[13.5px]">
-              <Text className="BTN1 text-medium_gray">비밀번호 찾기</Text>
-            </Pressable>
-          </View>
-        </KeyboardAwareScrollView>
-      </TouchableWithoutFeedback>
+        <View className="gap-y-3">
+          <CustomPressable buttonText="로그인" onPress={handleSubmit(onSubmit)} disabled={false} />
+          <TextButton onPress={() => router.push('/(onBoarding)/findPassword')}>
+            비밀번호 찾기
+          </TextButton>
+        </View>
+      </KeyBoardAwareProvider>
     </SafeAreaView>
   );
 }

--- a/app/(onBoarding)/register.tsx
+++ b/app/(onBoarding)/register.tsx
@@ -1,87 +1,86 @@
-import { router } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { useForm } from 'react-hook-form';
-import { Pressable, Text, TouchableWithoutFeedback } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import XIcon from '@/assets/icons/x.svg';
-import CustomPressableComponent from '@/components/common/customPressable';
-import InputControllerComponent from '@/components/onBoard/inputController';
+import BackHeaderComponent from '@/components/common/backHeader';
+import CTAContainer from '@/components/common/ctaContainer';
+import CustomPressable from '@/components/common/customPressable/customPressable';
+import RegisterForm from '@/components/onBoard/register/registerForm';
 import { useSignUp } from '@/hooks/auth/auth';
-import { useDomainModalStore } from '@/zustands/onBoard/store';
-
-type FormData = {
-  name: string;
-  email: string;
-  password: string;
-  passwordCheck: string;
-  phone: string;
-};
+import KeyBoardAwareProvider from '@/providers/keyBoardProvider';
+import { RegisterDto } from '@/types/auth';
+import {
+  emailValidate,
+  passwordCheckValidate,
+  passwordValidate,
+  // phoneValidate,
+} from '@/utils/validators';
 
 export default function Register() {
-  const formFields: { title: string; name: keyof FormData; placeholder: string }[] = [
+  const router = useRouter();
+
+  const formFields: {
+    title: string;
+    name: keyof RegisterDto;
+    placeholder: string;
+    validate?: (value: string, formValues: RegisterDto) => true | string | Promise<true | string>;
+  }[] = [
     { title: '이름', name: 'name', placeholder: '이름을 입력해주세요' },
-    { title: '이메일 아이디', name: 'email', placeholder: '예: dice16' },
-    { title: '비밀번호', name: 'password', placeholder: '비밀번호를 입력해주세요' },
+    {
+      title: '이메일 아이디',
+      name: 'email',
+      placeholder: '이메일을 입력해주세요',
+      validate: emailValidate,
+    },
+    {
+      title: '비밀번호',
+      name: 'password',
+      placeholder: '비밀번호를 입력해주세요',
+      validate: passwordValidate,
+    },
     {
       title: '비밀번호 확인',
       name: 'passwordCheck',
       placeholder: '비밀번호를 한번 더 입력해주세요',
+      validate: (value, password) => passwordCheckValidate(value, password!),
     },
-    { title: '휴대폰', name: 'phone', placeholder: '숫자만 입력해주세요' },
+    // { title: '휴대폰', name: 'phone', placeholder: '숫자만 입력해주세요', validate: phoneValidate },
   ];
 
   const {
     control,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormData>();
+  } = useForm<RegisterDto>({ mode: 'onChange' });
 
   const { mutateAsync: signUp } = useSignUp();
 
-  const onSubmit = async (data: FormData) => {
+  const onSubmit = async (data: RegisterDto) => {
     await signUp({
       email: data.email,
       name: data.name,
       password: data.password,
-      phone: data.phone,
+      // phone: data.phone,
       userRole: 1,
     });
   };
 
-  const { setIsDomainModalOpen } = useDomainModalStore();
-
   return (
-    <SafeAreaView className="flex-1 bg-white">
-      <Pressable onPress={() => router.back()} className="self-start p-[12px] ml-[3px]">
-        <XIcon />
-      </Pressable>
+    <SafeAreaView className="flex-1 bg-white relative">
+      <BackHeaderComponent style="WHITE" hasSafeArea={false} title="회원가입" />
 
-      <TouchableWithoutFeedback onPress={() => setIsDomainModalOpen(false)}>
-        <KeyboardAwareScrollView
-          contentContainerStyle={{ paddingHorizontal: 20, rowGap: 24, paddingBottom: 64 }}
-          keyboardShouldPersistTaps="handled"
-          enableOnAndroid={true}
-          extraScrollHeight={20}
-        >
-          <Text className="H1 text-black mt-[32px] mb-[8px]">회원가입</Text>
-          {formFields.map((field) => (
-            <InputControllerComponent
-              key={field.name}
-              control={control}
-              title={field.title}
-              name={field.name}
-              placeholder={field.placeholder}
-            />
-          ))}
-        </KeyboardAwareScrollView>
-      </TouchableWithoutFeedback>
+      <KeyBoardAwareProvider rowGap={11}>
+        <RegisterForm formFields={formFields} control={control} errors={errors} />
+      </KeyBoardAwareProvider>
 
-      <CustomPressableComponent
-        buttonText="회원가입"
-        onPress={handleSubmit(onSubmit)}
-        disabled={false}
-      />
+      <CTAContainer extraBottom={16}>
+        <CustomPressable
+          buttonText="다음"
+          // onPress={handleSubmit(onSubmit)}
+          onPress={() => router.push('/(onBoarding)/brandProfile')}
+          disabled={false}
+        />
+      </CTAContainer>
     </SafeAreaView>
   );
 }

--- a/components/common/customPressable/customPressable.tsx
+++ b/components/common/customPressable/customPressable.tsx
@@ -6,16 +6,16 @@ import GlobeIcon from '@/assets/icons/globe.svg';
 import GrayDownArrowIcon from '@/assets/icons/grayDownArrow.svg';
 import GrayUpArrowIcon from '@/assets/icons/grayUpArrow.svg';
 
-interface CustomPressableComponentProps {
+interface CustomPressableProps {
   buttonText: string;
   onPress: any;
   disabled: boolean;
   color?: 'BLACK' | 'GRAY' | 'WHITE';
-  icon?: 'DICE' | 'GLOBE';
+  icon?: 'DICE' | 'GLOBE' | 'KAKAO';
   arrow?: 'DOWN' | 'UP';
 }
 
-const CustomPressableComponent: React.FC<CustomPressableComponentProps> = ({
+const CustomPressable: React.FC<CustomPressableProps> = ({
   buttonText,
   onPress,
   disabled,
@@ -27,7 +27,7 @@ const CustomPressableComponent: React.FC<CustomPressableComponentProps> = ({
 
   const buttonColorStyles = {
     BLACK: 'bg-black ',
-    GRAY: 'bg-light_gray ',
+    GRAY: 'bg-light_gray',
     WHITE: 'bg-white border border-stroke',
   };
 
@@ -57,7 +57,7 @@ const CustomPressableComponent: React.FC<CustomPressableComponentProps> = ({
       disabled={disabled}
       onPressIn={() => setIsPressed(true)}
       onPressOut={() => setIsPressed(false)}
-      className={`${isPressed && 'opacity-50'} mx-[20px]`}
+      className={`${isPressed && 'opacity-50'}`}
     >
       <View className={`${baseContainerStyle} ${buttonColorStyles[color]}`}>
         <View className="w-[24px] h-[24px] mr-[16px]" />
@@ -87,4 +87,4 @@ const CustomPressableComponent: React.FC<CustomPressableComponentProps> = ({
   );
 };
 
-export default CustomPressableComponent;
+export default CustomPressable;

--- a/components/common/customSelect.tsx
+++ b/components/common/customSelect.tsx
@@ -1,0 +1,58 @@
+import { Text, Pressable, View } from 'react-native';
+
+import { Items } from '@/constants/filtering';
+
+interface CustomSelectProps<T> {
+  label: string;
+  subLabel?: string;
+  required?: boolean;
+  options: Items<T>[];
+  value: T[];
+  setValue: (newValue: T[]) => void;
+  wrapGap?: string;
+  padding?: string;
+  rounded?: string;
+  textStyle?: string;
+}
+export default function CustomSelect<T>({
+  label,
+  subLabel,
+  required = false,
+  options,
+  value,
+  setValue,
+  wrapGap = 'gap-1',
+  padding = 'px-2.5 py-[9px]',
+  rounded = 'rounded',
+  textStyle = 'BTN1',
+}: CustomSelectProps<T>) {
+  const toggleSelect = <T,>(list: T[], value: T): T[] =>
+    list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+
+  return (
+    <View className="gap-y-[8px]">
+      <Text className="CAP1 text-dark_gray">
+        {label}
+        <Text className="text-semiLight_gray">{subLabel}</Text>
+        {required && <Text className="text-red">*</Text>}
+      </Text>
+
+      <View className={`flex flex-row flex-wrap items-center ${wrapGap}`}>
+        {options.map((item) => (
+          <Pressable
+            key={item.title}
+            onPress={() => setValue(toggleSelect(value, item.value))}
+            className={`flex flex-row items-center gap-x-0.5 border ${padding} ${rounded} ${value.includes(item.value) ? 'border-purple' : 'border-stroke'}`}
+          >
+            {item.icon && <item.icon />}
+            <Text
+              className={`${textStyle} ${value.includes(item.value) ? 'text-purple' : 'text-deep_gray'}`}
+            >
+              {item.title}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/common/customTextInput.tsx
+++ b/components/common/customTextInput.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Text, TextInput, View } from 'react-native';
+
+interface CustomTextInputProps {
+  label?: string;
+  subLabel?: string;
+  required?: boolean;
+  placeholder: string;
+  multiline?: boolean;
+  height?: string;
+  value: string;
+  setValue: (value: string) => void;
+  isPassword?: boolean;
+}
+
+export default function CustomTextInput({
+  label,
+  subLabel,
+  required = false,
+  placeholder,
+  multiline = false,
+  height,
+  value,
+  setValue,
+  isPassword = false,
+}: CustomTextInputProps) {
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
+  return (
+    <View className="gap-y-[8px]">
+      {label && (
+        <Text className="CAP1 text-dark_gray">
+          {label}
+          <Text className="text-semiLight_gray">{subLabel}</Text>
+          {required && <Text className="text-red">*</Text>}
+        </Text>
+      )}
+
+      <TextInput
+        value={value}
+        onChangeText={setValue}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        multiline={multiline}
+        placeholder={placeholder}
+        placeholderTextColor="#CCCCCC"
+        autoCapitalize="none"
+        secureTextEntry={isPassword}
+        className={`p-4 border ${isFocused ? 'border-black' : 'border-light_gray'} rounded-lg ${height}`}
+      />
+    </View>
+  );
+}

--- a/components/common/imageList.tsx
+++ b/components/common/imageList.tsx
@@ -1,0 +1,61 @@
+import { Image } from 'expo-image';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+
+import PlusIcon from '@/assets/icons/myPage/plus.svg';
+import RoundXIcon from '@/assets/icons/roundX.svg';
+
+interface HorizontalImageListProps {
+  label: string;
+  subLabel?: string;
+  value: string[];
+  setValue: (value: string[]) => void;
+}
+
+export default function HorizontalImageList({
+  label,
+  subLabel,
+  value,
+  setValue,
+}: HorizontalImageListProps) {
+  return (
+    <View className="overflow-visible">
+      <Text className="CAP1 text-dark_gray">
+        {label}
+        <Text className="text-semiLight_gray">{subLabel}</Text>
+      </Text>
+      <ScrollView
+        horizontal={true}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{
+          flexDirection: 'row',
+          columnGap: 6,
+          overflow: 'visible',
+          paddingTop: 8,
+        }}
+      >
+        <Pressable
+          //   onPress={onPressImages}
+          className="bg-white flex justify-center items-center rounded-xl border border-light_gray w-[80px] h-[80px]"
+        >
+          <PlusIcon />
+          <Text className="CAP2 text-medium_gray text-center">
+            <Text className="text-purple">{value.length}</Text> / 10
+          </Text>
+        </Pressable>
+        {value.map((item) => (
+          <View key={item} className="relative">
+            <Image source={{ uri: item }} style={{ width: 80, height: 80, borderRadius: 12 }} />
+            <Pressable
+              //   onPress={() => {
+              //     setImageUrls((prev) => prev.filter((url) => url !== item));
+              //   }}
+              className="absolute -top-2 -right-2 z-10 overflow-visible"
+            >
+              <RoundXIcon />
+            </Pressable>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/components/common/textButton.tsx
+++ b/components/common/textButton.tsx
@@ -1,0 +1,22 @@
+import { ReactNode, useState } from 'react';
+import { Pressable, Text } from 'react-native';
+
+interface TextButtonProps {
+  children: ReactNode;
+  onPress: () => void;
+}
+
+export default function TextButton({ children, onPress }: TextButtonProps) {
+  const [isPressed, setIsPressed] = useState<boolean>(false);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      className={`self-center px-[16px] py-[13.5px] ${isPressed && 'opacity-60'}`}
+    >
+      <Text className="BTN1 text-medium_gray text-center underline">{children}</Text>
+    </Pressable>
+  );
+}

--- a/components/onBoard/login/loginForm.tsx
+++ b/components/onBoard/login/loginForm.tsx
@@ -1,0 +1,39 @@
+import { Control, Controller } from 'react-hook-form';
+import { Text, View } from 'react-native';
+
+import CustomTextInput from '@/components/common/customTextInput';
+import { LoginDto } from '@/types/auth';
+
+interface LoginFormProps {
+  formFields: { name: keyof LoginDto; placeholder: string }[];
+  control: Control<LoginDto, any, LoginDto>;
+}
+
+export default function LoginForm({ formFields, control }: LoginFormProps) {
+  return (
+    <View className="gap-y-[32px]">
+      <Text className="H1 text-black">로그인</Text>
+
+      <View className="gap-y-[12px]">
+        {formFields.map((item) => (
+          <Controller
+            key={item.name}
+            name={item.name}
+            control={control}
+            rules={{
+              required: true,
+            }}
+            render={({ field: { onChange, onBlur, value } }) => (
+              <CustomTextInput
+                value={value}
+                setValue={onChange}
+                placeholder={item.placeholder}
+                isPassword={item.name === 'password'}
+              />
+            )}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/onBoard/register/registerForm.tsx
+++ b/components/onBoard/register/registerForm.tsx
@@ -1,0 +1,74 @@
+import { Control, Controller, FieldErrors } from 'react-hook-form';
+import { Text, View } from 'react-native';
+
+import CustomTextInput from '@/components/common/customTextInput';
+import { RegisterDto } from '@/types/auth';
+
+interface RegisterFormProps {
+  formFields: {
+    title: string;
+    name: keyof RegisterDto;
+    placeholder: string;
+    validate?: (value: string, formValues: RegisterDto) => true | string | Promise<true | string>;
+  }[];
+  control: Control<RegisterDto, any, RegisterDto>;
+  errors: FieldErrors<RegisterDto>;
+}
+
+const successMessages: Record<keyof RegisterDto, string> = {
+  name: '', // 이름은 성공 메시지 없음
+  email: '사용 가능한 이메일입니다.',
+  password: '사용 가능한 비밀번호입니다.',
+  passwordCheck: '동일한 비밀번호입니다.',
+  phone: '사용 가능한 휴대폰 번호입니다.',
+};
+
+export default function RegisterForm({ formFields, control, errors }: RegisterFormProps) {
+  return (
+    <View className="gap-y-[32px] pt-[32px]">
+      <Text className="H1 text-black">회원 정보를 입력해주세요</Text>
+
+      <View className="gap-y-[24px]">
+        {formFields.map((item) => (
+          <Controller
+            key={item.name}
+            name={item.name}
+            control={control}
+            rules={{
+              required: `${item.title}은(는) 필수 입력입니다.`,
+              validate: item.validate,
+            }}
+            render={({ field: { onChange, value } }) => {
+              const errorMessage = errors[item.name]?.message as string | undefined;
+              const successMessage = !errorMessage && value ? successMessages[item.name] : '';
+
+              return (
+                <View>
+                  <Text className="CAP1 text-dark_gray mb-[8px] ml-[4px]">
+                    {item.title}
+                    <Text className="text-red">*</Text>
+                  </Text>
+
+                  <CustomTextInput
+                    value={value}
+                    setValue={onChange}
+                    placeholder={item.placeholder}
+                    isPassword={item.name === 'password' || item.name === 'passwordCheck'}
+                  />
+
+                  <Text
+                    className={`CAP2 mt-[4px] ml-[4px] ${
+                      errorMessage ? 'text-red' : successMessage ? 'text-green' : 'hidden'
+                    }`}
+                  >
+                    {errorMessage || successMessage}
+                  </Text>
+                </View>
+              );
+            }}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/constants/filtering.ts
+++ b/constants/filtering.ts
@@ -1,4 +1,88 @@
+import { SvgProps } from 'react-native-svg';
+
+import FemaleIcon from '@/assets/icons/filtering/female.svg';
+import MaleIcon from '@/assets/icons/filtering/male.svg';
+
+export type Items<T> = {
+  title: string;
+  value: T;
+  icon?: React.FC<SvgProps>;
+};
+
+export const genderItems = [
+  { title: '여성', value: 'female', icon: FemaleIcon },
+  { title: '남성', value: 'male', icon: MaleIcon },
+];
+
+export const ageRangeItems = [
+  { title: '10대이하', value: 10 },
+  { title: '20대', value: 20 },
+  { title: '30대', value: 30 },
+  { title: '40대', value: 40 },
+  { title: '50대', value: 50 },
+  { title: '60대이상', value: 60 },
+];
+
+export const dayOfWeekItems = [
+  { title: '월', value: 'monday' },
+  { title: '화', value: 'tuesday' },
+  { title: '수', value: 'wednesday' },
+  { title: '목', value: 'thursday' },
+  { title: '금', value: 'friday' },
+  { title: '토', value: 'saturday' },
+  { title: '일', value: 'sunday' },
+];
+
+export const purposeItems = [
+  { title: '사진 촬영', value: 'snapshot' },
+  { title: '쇼핑', value: 'shopping' },
+  { title: '카페/맛집 탐방', value: 'tour' },
+  { title: '전시 관람', value: 'exhibition' },
+  { title: '데이트', value: 'date' },
+];
+
+export const sizeItems = [
+  { title: '10평 이하', min: 0, max: 10 },
+  { title: '10평대', min: 10, max: 20 },
+  { title: '20평대', min: 20, max: 30 },
+  { title: '30평대', min: 30, max: 40 },
+  { title: '40평대', min: 40, max: 50 },
+  { title: '50평대', min: 50, max: 60 },
+  { title: '60평대', min: 60, max: 70 },
+  { title: '70평대', min: 70, max: 80 },
+  { title: '80평대', min: 80, max: 90 },
+  { title: '90평대', min: 90, max: 100 },
+  { title: '100평대', min: 100, max: 110 },
+  { title: '110평대', min: 110, max: 120 },
+  { title: '120평대', min: 120, max: 130 },
+  { title: '130평대', min: 130, max: 140 },
+  { title: '140평대', min: 140, max: 150 },
+  { title: '150평대 이상', min: 150, max: 150 },
+];
+
+export const priceItems = [
+  { title: '10만원 이하', min: 0, max: 100000 },
+  { title: '10만원대', min: 100000, max: 200000 },
+  { title: '20만원대', min: 200000, max: 300000 },
+  { title: '30만원대', min: 300000, max: 400000 },
+  { title: '40만원대', min: 400000, max: 500000 },
+  { title: '50만원대', min: 500000, max: 600000 },
+  { title: '60만원대', min: 600000, max: 700000 },
+  { title: '70만원대', min: 700000, max: 800000 },
+  { title: '80만원대', min: 800000, max: 900000 },
+  { title: '90만원대', min: 900000, max: 1000000 },
+  { title: '100만원대 이상', min: 1000000, max: 1000000 },
+];
+
+export const spaceSortByItems = [
+  { title: '인기 순', value: 'likeCount' },
+  { title: '최신 순', value: 'latest' },
+  { title: '낮은 가격 순', value: 'priceAsc' },
+  { title: '높은 가격 순', value: 'priceDesc' },
+];
+
 export const targetsItems = [
+  { title: '전체', value: '전체' },
   { title: '자영업자', value: '자영업자' },
   { title: '소상공인', value: '소상공인' },
 ];
@@ -7,4 +91,10 @@ export const statusItems = [
   { title: '모집 중', value: 'RECRUITING' },
   { title: '모집 예정', value: 'COMPLETED' },
   { title: '모집 마감', value: 'CLOSED' },
+];
+
+export const announcementSoryByItems = [
+  { title: '인기 순', value: 'likeCount' },
+  { title: '최신 순', value: 'latest' },
+  { title: '마감 순', value: 'closing' },
 ];

--- a/providers/keyBoardProvider.tsx
+++ b/providers/keyBoardProvider.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+
+interface KeyBoardAwareProviderProps {
+  children: ReactNode;
+  isCenter?: boolean;
+  rowGap?: string | number;
+}
+
+export default function KeyBoardAwareProvider({
+  children,
+  isCenter = false,
+  rowGap,
+}: KeyBoardAwareProviderProps) {
+  return (
+    <KeyboardAwareScrollView
+      contentContainerStyle={{
+        flexGrow: 1,
+        justifyContent: isCenter ? 'center' : 'flex-start',
+        paddingHorizontal: 20,
+        rowGap: rowGap,
+        paddingBottom: 80,
+      }}
+      keyboardShouldPersistTaps="handled"
+      enableOnAndroid={true}
+      extraScrollHeight={20}
+    >
+      {children}
+    </KeyboardAwareScrollView>
+  );
+}

--- a/server/auth/auth.ts
+++ b/server/auth/auth.ts
@@ -22,56 +22,56 @@ import {
 
 // 회원 탈퇴
 export const withdraw = async () => {
-  const response = await PostAxiosInstance(`/auth/withdraw`);
+  const response = await PostAxiosInstance(`/v1/auth/withdraw`);
 
   return response.data;
 };
 
 // 이메일 인증 전송
 export const sendEmailVerify = async (data: SendEmailVerifyRequest) => {
-  const response = await GuestPostAxiosInstance(`/auth/verify`, data);
+  const response = await GuestPostAxiosInstance(`/v1/auth/verify`, data);
 
   return response.data;
 };
 
 // 이메일 인증 확인
 export const verifyEmail = async (data: VerifyEmailRequest): Promise<VerifyEmailResponse> => {
-  const response = await GuestPostAxiosInstance<VerifyEmailResponse>(`/auth/verify/code`, data);
+  const response = await GuestPostAxiosInstance<VerifyEmailResponse>(`/v1/auth/verify/code`, data);
 
   return response.data;
 };
 
 // 휴대폰 번호 중복 확인
 export const checkPhoneNumber = async (data: CheckPhoneNumberRequest) => {
-  const response = await GuestPostAxiosInstance(`/auth/validate/phone`, data);
+  const response = await GuestPostAxiosInstance(`/v1/auth/validate/phone`, data);
 
   return response.data;
 };
 
 // 이메일 중복 확인
 export const checkEmail = async (data: CheckEmailRequest) => {
-  const response = await GuestPostAxiosInstance(`/auth/validate/email`, data);
+  const response = await GuestPostAxiosInstance(`/v1/auth/validate/email`, data);
 
   return response.data;
 };
 
 // 회원가입
 export const signUp = async (data: SignUpRequest): Promise<SignUpResponse> => {
-  const response = await GuestPostAxiosInstance<SignUpResponse>(`/auth/signup`, data);
+  const response = await GuestPostAxiosInstance<SignUpResponse>(`/v2/auth/signup`, data);
 
   return response.data;
 };
 
 // 토큰 재발급
 export const reissueToken = async (data: ReissueTokenRequest): Promise<ReissueTokenResponse> => {
-  const response = await PostAxiosInstance<ReissueTokenResponse>(`/auth/reissue`, data);
+  const response = await PostAxiosInstance<ReissueTokenResponse>(`/v1/auth/reissue`, data);
 
   return response.data;
 };
 
 // 비밀번호 변경
 export const updatePassword = async (data: UpdatePasswordRequest) => {
-  const response = await PostAxiosInstance(`/auth/password-update`, data);
+  const response = await PostAxiosInstance(`/v1/auth/password-update`, data);
 
   return response.data;
 };
@@ -79,7 +79,7 @@ export const updatePassword = async (data: UpdatePasswordRequest) => {
 // 비밀번호 재설정
 export const resetPassword = async (data: ResetPasswordRequest): Promise<ResetPasswordResponse> => {
   const response = await GuestPostAxiosInstance<ResetPasswordResponse>(
-    `/auth/password-reset`,
+    `/v1/auth/password-reset`,
     data,
   );
 
@@ -88,14 +88,14 @@ export const resetPassword = async (data: ResetPasswordRequest): Promise<ResetPa
 
 // 로그아웃
 export const logout = async () => {
-  const response = await PostAxiosInstance(`/auth/logout`);
+  const response = await PostAxiosInstance(`/v1/auth/logout`);
 
   return response.data;
 };
 
 // 이메일 로그인
 export const login = async (data: LoginRequest): Promise<LoginResponse> => {
-  const response = await GuestPostAxiosInstance<LoginResponse>(`/auth/login`, data);
+  const response = await GuestPostAxiosInstance<LoginResponse>(`/v1/auth/login`, data);
 
   return response.data;
 };

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,12 @@
+export type RegisterDto = {
+  name: string;
+  email: string;
+  password: string;
+  passwordCheck: string;
+  phone: string;
+};
+
+export type LoginDto = {
+  email: string;
+  password: string;
+};

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,0 +1,58 @@
+import { checkEmail, checkPhoneNumber } from '@/server/auth/auth';
+import { RegisterDto } from '@/types/auth';
+
+export const emailValidate = async (value: string) => {
+  if (!value || value.trim() === '') {
+    return '이메일을 입력해주세요.';
+  }
+
+  try {
+    await checkEmail({ email: value });
+    return true; // 통과
+  } catch (error: any) {
+    if (error?.response?.status === 409) {
+      return '이미 가입된 이메일입니다.';
+    }
+    return '이메일 확인 중 오류가 발생했습니다.';
+  }
+};
+
+export const passwordValidate = (value: string) => {
+  if (!value || value.length === 0) {
+    return '비밀번호는 8자 이상 / 영문, 숫자, 특수문자를 포함해야 합니다.';
+  }
+  if (value.length < 8) {
+    return '최소 8자 이상 입력해야 합니다.';
+  }
+
+  const hasLetter = /[A-Za-z]/.test(value);
+  const hasNumber = /[0-9]/.test(value);
+  const hasSpecial = /[!@#$%^&*()_+=-]/.test(value);
+
+  if (hasLetter && hasNumber && hasSpecial) {
+    return true;
+  }
+  return '영문, 숫자, 특수문자 모두 포함해야 합니다.';
+};
+
+export const passwordCheckValidate = (value: string, formValues: RegisterDto) => {
+  if (!value) return '비밀번호 확인을 입력해주세요.';
+  if (value !== formValues.password) return '동일한 비밀번호를 입력해야 합니다.';
+  return true;
+};
+
+export const phoneValidate = async (value: string) => {
+  if (!/^\d{11}$/.test(value)) {
+    return '휴대폰 번호는 11자리 숫자만 입력해야 합니다.';
+  }
+
+  try {
+    await checkPhoneNumber({ phone: value });
+    return true;
+  } catch (error: any) {
+    if (error?.response?.status === 409) {
+      return '중복된 휴대폰 번호입니다.';
+    }
+    return '휴대폰 확인 중 오류가 발생했습니다.';
+  }
+};

--- a/zustands/onBoard/store.ts
+++ b/zustands/onBoard/store.ts
@@ -1,5 +1,88 @@
 import { create } from 'zustand';
 
+import { SignUpStore } from './type';
+
+export const useSignUpStore = create<{
+  signUpStore: SignUpStore;
+  setSignUpStore: (state: Partial<SignUpStore>) => void;
+
+  setTargetGender: (genders: string[]) => void;
+  setTargetAgeGroup: (ages: number[]) => void;
+  setBrandName: (name: string) => void;
+  setBrandDescription: (desc: string) => void;
+  setLogoUrl: (url: string) => void;
+  setImageUrls: (urls: string[]) => void;
+}>((set) => ({
+  signUpStore: {
+    signUp: {
+      email: '',
+      name: '',
+      password: '',
+      phone: '',
+      userRole: 1,
+    },
+    brandProfile: {
+      targetGender: [],
+      targetAgeGroup: [],
+      name: '',
+      description: '',
+      logoUrl: '',
+      imageUrls: [],
+    },
+  },
+  setSignUpStore: (newState) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        ...newState,
+      },
+    })),
+
+  // 브랜드 프로필 관련 setters
+  setTargetGender: (targetGender: string[]) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        brandProfile: { ...state.signUpStore.brandProfile, targetGender },
+      },
+    })),
+  setTargetAgeGroup: (targetAgeGroup: number[]) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        brandProfile: { ...state.signUpStore.brandProfile, targetAgeGroup },
+      },
+    })),
+  setBrandName: (name: string) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        brandProfile: { ...state.signUpStore.brandProfile, name },
+      },
+    })),
+  setBrandDescription: (description: string) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        brandProfile: { ...state.signUpStore.brandProfile, description },
+      },
+    })),
+  setLogoUrl: (logoUrl: string) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        brandProfile: { ...state.signUpStore.brandProfile, logoUrl },
+      },
+    })),
+  setImageUrls: (imageUrls: string[]) =>
+    set((state) => ({
+      signUpStore: {
+        ...state.signUpStore,
+        brandProfile: { ...state.signUpStore.brandProfile, imageUrls },
+      },
+    })),
+}));
+
 // 이메일 도메인 선택 모달 store
 export const useDomainModalStore = create<{
   isDomainModalOpen: boolean;

--- a/zustands/onBoard/type.ts
+++ b/zustands/onBoard/type.ts
@@ -1,0 +1,17 @@
+export interface SignUpStore {
+  signUp: {
+    email: string;
+    name: string;
+    password: string;
+    phone?: string;
+    userRole: 1 | 0;
+  };
+  brandProfile: {
+    targetGender: string[];
+    targetAgeGroup: number[];
+    name: string;
+    description: string;
+    logoUrl: string;
+    imageUrls: string[];
+  };
+}


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[DICE-23] 온보딩 관련 스크린 수정 (로그인 / 회원가입 등)

## 📌 반영 브랜치
DICE-23 -> dev

## 📋 내용
### 💻 온보딩 스크린 - 로그인
- [x] 로그인 스크린의 코드를 수정했습니다. (컴포넌트 구분)
<img src="https://github.com/user-attachments/assets/6e26e6e6-685c-4230-92a2-1fd06655b509" width="250" />

---

### 💻 온보딩 스크린 - 회원가입
- [x] 회원가입 스크린의 코드를 수정했습니다. (컴포넌트 구분)
- [x] 게스트 앱에서는 게스트의 전화번호를 받지 않는 것으로 수정하여 반영하였습니다.
- [x] 유효성 검사 (validation)을 분리하여 사용하였습니다.
<img src="https://github.com/user-attachments/assets/2369f15e-c7d6-48d9-8e5a-34ac9ce21aa5" width="250" />

---

### 💻 온보딩 스크린 - 브랜드 프로필 등록
- [x] 게스트 회원가입 후 바로 브랜드 프로필을 등록할 수 있도록 해당 스크린을 추가했습니다.
<img src="https://github.com/user-attachments/assets/557e107a-55b1-424a-a4c5-388a15e49a82" width="250" />

## 🚨 유의 사항
- [ ] 브랜드 프로필이 등록되어있는지에 대한 상태를 추가해야될 것 같습니다.

[DICE-23]: https://devjjhyeok13.atlassian.net/browse/DICE-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Brand Profile step to onboarding (after Register), collecting target gender/age, brand name/description, and images, with a gated CTA.
  - Introduced reusable inputs (select, text input, horizontal image list) and a text-only button; primary button now supports a Kakao icon and refined styling.

- UX/Refactor
  - Redesigned Login and Register screens with modular forms and keyboard-aware layouts.
  - Improved validation and feedback: async email/phone checks, password strength and confirmation messages.
  - Updated navigation flow to progress from Register to Brand Profile via a clear CTA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->