### PR TITLE
[DICE-24] (tabs) 화면 - 예약 관리 스크린 리팩토링

### DIFF
--- a/app/(tabs)/reservation.tsx
+++ b/app/(tabs)/reservation.tsx
@@ -1,72 +1,45 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Dimensions, FlatList, RefreshControl, Text, View } from 'react-native';
+import { useState } from 'react';
+import { Dimensions, View } from 'react-native';
+import { SceneMap, TabBar, TabView } from 'react-native-tab-view';
 
-import CoverViewComponent from '@/components/common/coverView';
-import ReservationItemComponent from '@/components/common/reservationItem';
-import HeaderComponent from '@/components/reservation/header';
+import AcceptReservationList from '@/components/reservation/acceptReservationList';
+import CancelReservationList from '@/components/reservation/cancelReservationList';
+import PendingReservationList from '@/components/reservation/pendingReservationList';
 import TopNavigationComponent from '@/components/tabs/topNavigation';
-import { reservationData } from '@/constants/dummyData/reservationList';
-import { useGetReservationLists } from '@/hooks/reservation/reservation';
-// import { ReservationItem } from '@/types/reservation';
+
+const renderScene = SceneMap({
+  PENDING: PendingReservationList,
+  ACCEPT: AcceptReservationList,
+  CANCEL: CancelReservationList,
+});
 
 export default function Reservation() {
-  const [currentType, setCurrentType] = useState<'PENDING' | 'ACCEPT' | 'CANCEL'>('PENDING');
+  const [index, setIndex] = useState(0);
 
-  // const { data, hasNextPage, fetchNextPage, refetch } = useGetReservationLists(currentType);
-  const data = reservationData;
-
-  const [refreshing, setRefreshing] = useState<boolean>(false);
-
-  const onRefresh = useCallback(() => {
-    // refetch();
-    setTimeout(() => {
-      setRefreshing(false);
-    }, 1500);
-  }, []);
+  const [routes] = useState([
+    { key: 'PENDING', title: '대기중' },
+    { key: 'ACCEPT', title: '예약 완료' },
+    { key: 'CANCEL', title: '예약 취소' },
+  ]);
 
   return (
     <View className="flex-1 bg-white">
       <TopNavigationComponent title="예약 관리" />
-      <CoverViewComponent height={500} top={-100} />
 
-      <FlatList
-        contentContainerStyle={{
-          flexGrow: 1,
-          paddingBottom: 64,
-          backgroundColor: '#FFFFFF',
-          rowGap: 16,
-        }}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-            progressBackgroundColor={'#FFFFFF'}
-            title="조회중"
-            tintColor={'#FFFFFF'}
-            titleColor={'#FFFFFF'}
+      <TabView
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        onIndexChange={setIndex}
+        initialLayout={{ width: Dimensions.get('screen').width }}
+        renderTabBar={(props) => (
+          <TabBar
+            {...props}
+            indicatorStyle={{ backgroundColor: '#000000' }}
+            style={{ backgroundColor: '#F4F4F4' }}
+            activeColor="#000000"
+            inactiveColor="#999999"
           />
-        }
-        // data={data?.pages.flatMap((page) => page.content)}
-        data={data}
-        stickyHeaderIndices={[0]}
-        ListHeaderComponent={
-          <HeaderComponent currentType={currentType} setCurrentType={setCurrentType} />
-        }
-        renderItem={({ item }) => (
-          <ReservationItemComponent key={item.reservationId} type={currentType} data={item} />
         )}
-        ItemSeparatorComponent={() => <View className="h-[16px]" />}
-        ListEmptyComponent={() => (
-          <View className="flex-1 flex justify-center items-center">
-            <Text className="BODY1 text-deep_gray text-center">아직 예약 내역이 없어요</Text>
-          </View>
-        )}
-        onEndReachedThreshold={0.5}
-        // onEndReached={() => {
-        //   if (hasNextPage) {
-        //     fetchNextPage();
-        //   }
-        // }}
       />
     </View>
   );

--- a/components/reservation/acceptReservationList.tsx
+++ b/components/reservation/acceptReservationList.tsx
@@ -1,0 +1,67 @@
+import { FlatList, Pressable, Text, View } from 'react-native';
+
+import SmallGrayDownArrowIcon from '@/assets/icons/small-grayDownArrow.svg';
+import { useGetReservationLists } from '@/hooks/reservation/reservation';
+
+import SpaceSkeletonItem from '../spaceSkeleton';
+
+import ReservationItem from './item/reservationItem';
+
+export default function AcceptReservationList() {
+  const { data, isLoading, hasNextPage, fetchNextPage, isError } = useGetReservationLists('ACCEPT');
+
+  const acceptReservationData =
+    data?.pages.flatMap((page) => page.content.map((item) => ({ ...item }))) ?? [];
+
+  if (isError) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text className="BODY1 text-red">잘못된 요청입니다!</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      contentContainerStyle={{
+        flexGrow: 1,
+        paddingBottom: 64,
+        backgroundColor: '#FFFFFF',
+      }}
+      data={
+        isLoading
+          ? Array.from({ length: 3 }).map(() => null) // Skeleton용
+          : acceptReservationData
+      }
+      renderItem={({ item, index }) =>
+        item ? (
+          <ReservationItem key={item.reservationId} type={'ACCEPT'} data={item} />
+        ) : (
+          <SpaceSkeletonItem key={index} />
+        )
+      }
+      keyExtractor={(item, index) => (item ? `${item.reservationId}` : `skeleton-${index}`)}
+      stickyHeaderIndices={[0]}
+      ListHeaderComponent={() => (
+        <View className="bg-white px-[20px] py-[16px]">
+          <Pressable className="self-start flex flex-row items-center gap-x-[2px] pl-[12px] py-[5.5px] pr-[8px] border border-stroke rounded-full bg-back_gray">
+            <Text className="BTN1 text-deep_gray">최신순</Text>
+            <SmallGrayDownArrowIcon />
+          </Pressable>
+        </View>
+      )}
+      ItemSeparatorComponent={() => <View className="h-[16px]" />}
+      ListEmptyComponent={() => (
+        <View className="flex-1 flex justify-center items-center">
+          <Text className="BODY1 text-deep_gray text-center">아직 예약 내역이 없어요</Text>
+        </View>
+      )}
+      onEndReachedThreshold={0.5}
+      onEndReached={() => {
+        if (hasNextPage) {
+          fetchNextPage();
+        }
+      }}
+    />
+  );
+}

--- a/components/reservation/cancelReservationList.tsx
+++ b/components/reservation/cancelReservationList.tsx
@@ -1,0 +1,67 @@
+import { FlatList, Pressable, Text, View } from 'react-native';
+
+import SmallGrayDownArrowIcon from '@/assets/icons/small-grayDownArrow.svg';
+import { useGetReservationLists } from '@/hooks/reservation/reservation';
+
+import SpaceSkeletonItem from '../spaceSkeleton';
+
+import ReservationItem from './item/reservationItem';
+
+export default function CancelReservationList() {
+  const { data, isLoading, hasNextPage, fetchNextPage, isError } = useGetReservationLists('CANCEL');
+
+  const cancelReservationData =
+    data?.pages.flatMap((page) => page.content.map((item) => ({ ...item }))) ?? [];
+
+  if (isError) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text className="BODY1 text-red">잘못된 요청입니다!</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      contentContainerStyle={{
+        flexGrow: 1,
+        paddingBottom: 64,
+        backgroundColor: '#FFFFFF',
+      }}
+      data={
+        isLoading
+          ? Array.from({ length: 3 }).map(() => null) // Skeleton용
+          : cancelReservationData
+      }
+      renderItem={({ item, index }) =>
+        item ? (
+          <ReservationItem key={item.reservationId} type={'CANCEL'} data={item} />
+        ) : (
+          <SpaceSkeletonItem key={index} />
+        )
+      }
+      keyExtractor={(item, index) => (item ? `${item.reservationId}` : `skeleton-${index}`)}
+      stickyHeaderIndices={[0]}
+      ListHeaderComponent={() => (
+        <View className="bg-white px-[20px] py-[16px]">
+          <Pressable className="self-start flex flex-row items-center gap-x-[2px] pl-[12px] py-[5.5px] pr-[8px] border border-stroke rounded-full bg-back_gray">
+            <Text className="BTN1 text-deep_gray">최신순</Text>
+            <SmallGrayDownArrowIcon />
+          </Pressable>
+        </View>
+      )}
+      ItemSeparatorComponent={() => <View className="h-[16px]" />}
+      ListEmptyComponent={() => (
+        <View className="flex-1 flex justify-center items-center">
+          <Text className="BODY1 text-deep_gray text-center">아직 예약 내역이 없어요</Text>
+        </View>
+      )}
+      onEndReachedThreshold={0.5}
+      onEndReached={() => {
+        if (hasNextPage) {
+          fetchNextPage();
+        }
+      }}
+    />
+  );
+}

--- a/components/reservation/pendingReservationList.tsx
+++ b/components/reservation/pendingReservationList.tsx
@@ -1,0 +1,59 @@
+import { FlatList, Pressable, Text, View } from 'react-native';
+
+import SmallGrayDownArrowIcon from '@/assets/icons/small-grayDownArrow.svg';
+import { useGetReservationLists } from '@/hooks/reservation/reservation';
+
+import ReservationSkeletonItem from '../reservationSkeleton';
+
+import ReservationItem from './item/reservationItem';
+
+export default function PendingReservationList() {
+  const { data, isLoading, hasNextPage, fetchNextPage } = useGetReservationLists('PENDING');
+
+  const pendingReservationData =
+    data?.pages.flatMap((page) => page.content.map((item) => ({ ...item }))) ?? [];
+
+  return (
+    <FlatList
+      contentContainerStyle={{
+        flexGrow: 1,
+        paddingBottom: 64,
+        backgroundColor: '#FFFFFF',
+      }}
+      data={
+        isLoading
+          ? Array.from({ length: 3 }).map(() => null) // Skeleton용
+          : pendingReservationData
+      }
+      renderItem={({ item, index }) =>
+        item ? (
+          <ReservationItem key={item.reservationId} type={'PENDING'} data={item} />
+        ) : (
+          <ReservationSkeletonItem key={index} />
+        )
+      }
+      keyExtractor={(item, index) => (item ? `${item.reservationId}` : `skeleton-${index}`)}
+      stickyHeaderIndices={[0]}
+      ListHeaderComponent={() => (
+        <View className="bg-white px-[20px] py-[16px]">
+          <Pressable className="self-start flex flex-row items-center gap-x-[2px] pl-[12px] py-[5.5px] pr-[8px] border border-stroke rounded-full bg-back_gray">
+            <Text className="BTN1 text-deep_gray">최신순</Text>
+            <SmallGrayDownArrowIcon />
+          </Pressable>
+        </View>
+      )}
+      ListEmptyComponent={() => (
+        <View className="flex-1 flex justify-center items-center">
+          <Text className="BODY1 text-deep_gray text-center">아직 예약 내역이 없어요</Text>
+        </View>
+      )}
+      ItemSeparatorComponent={() => <View className="h-[16px]" />}
+      onEndReachedThreshold={0.5}
+      onEndReached={() => {
+        if (hasNextPage) {
+          fetchNextPage();
+        }
+      }}
+    />
+  );
+}

--- a/components/reservationSkeleton.tsx
+++ b/components/reservationSkeleton.tsx
@@ -1,0 +1,61 @@
+import ContentLoader, { Rect } from 'react-content-loader/native';
+import { Dimensions, View, Text } from 'react-native';
+
+export default function ReservationSkeletonItem() {
+  return (
+    <View className="border border-stroke rounded-lg mx-[20px] bg-white relative">
+      <ContentLoader
+        speed={2}
+        width={Dimensions.get('screen').width - 40}
+        height={296}
+        backgroundColor="#ecebeb"
+        foregroundColor="#f3f3f3"
+      >
+        {/* 공간 주소 */}
+        <Rect x="16" y="24" rx="4" ry="4" width="100" height="20" />
+        {/* 공간 이름 */}
+        <Rect x="16" y="46" rx="4" ry="4" width="150" height="31" />
+        {/* 면적 */}
+        <Rect x="16" y="85" rx="4" ry="4" width="120" height="20" />
+
+        {/* 이미지 */}
+        <Rect x="199" y="16" rx="12" ry="12" width="120" height="120" />
+
+        {/* 대여 기간 */}
+        <Rect
+          x={Dimensions.get('screen').width - 198}
+          y="160"
+          rx="4"
+          ry="4"
+          width="142"
+          height="20"
+        />
+        {/* 총 대여 금액 */}
+        <Rect
+          x={Dimensions.get('screen').width - 168}
+          y="184"
+          rx="4"
+          ry="4"
+          width="112"
+          height="28"
+        />
+
+        {/* 버튼 */}
+        <Rect
+          x="16"
+          y="228"
+          rx="8"
+          ry="8"
+          width={Dimensions.get('screen').width - 72}
+          height="52"
+        />
+      </ContentLoader>
+
+      {/* 텍스트를 ContentLoader 위에 올리기 위해 absolute 배치 */}
+      <Text className="CAP1 text-semiLight_gray absolute left-[16px] top-[160px]">대여 기간</Text>
+      <Text className="CAP1 text-semiLight_gray absolute left-[16px] top-[188px]">
+        총 대여 금액
+      </Text>
+    </View>
+  );
+}

--- a/hooks/reservation/reservation.ts
+++ b/hooks/reservation/reservation.ts
@@ -52,10 +52,7 @@ export const useCancelReservation = (status: 'PENDING' | 'ACCEPT' | 'CANCEL') =>
 export const useGetReservationLists = (status: string) => {
   return useInfiniteQuery({
     queryKey: [`/reservation/list`, status],
-    queryFn: async ({ pageParam }) => {
-      const response = getReservationLists(status, pageParam, 5);
-      return response;
-    },
+    queryFn: async ({ pageParam }) => getReservationLists(status, pageParam, 5),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage.last) {


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[DICE-24] (tabs) 화면 - 예약 관리 스크린 리팩토링

## 📌 반영 브랜치
DICE-24 -> dev

## 📋 내용
### 💻 예약 관리 스크린
- [x] 기존에 state로 저장한 type 값으로 API 호출 및 데이터를 변경하는 방식에서 react-native-tab-view를 활용하도록 리팩토링 했습니다.
- [x] 데이터를 로딩하는 중에 Skeleton UI가 보이도록 해당 컴포넌트를 구현했습니다.
<img src="https://github.com/user-attachments/assets/dd798989-3d14-485b-b5a7-01a6f5bb291e" width="250" />
<img src="https://github.com/user-attachments/assets/7fa5f69b-a871-466b-8c6a-f45f7355b838" width="250" />

## 🚨 유의 사항
- [x] 없음

[DICE-24]: https://devjjhyeok13.atlassian.net/browse/DICE-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a tabbed Reservations screen with Pending, Accepted, and Canceled tabs (Korean titles).
  - Added infinite scrolling for reservation lists with smooth pagination.
  - Implemented loading skeletons and clear empty states for each tab.
  - Displayed concise error messages when requests fail.
  - Added a sticky header with a simple “latest” sort control in each list.
- Refactor
  - Reworked the Reservations screen from a single list to tab-based scenes with consistent tab bar styling.
  - Removed legacy header, refresh controls, and inline data fetching UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->