### PR TITLE
[DICE-27] 공간 및 공고 좋아요 목록 스크린 수정

### DIFF
--- a/app/(topTabs)/like.tsx
+++ b/app/(topTabs)/like.tsx
@@ -1,77 +1,43 @@
+import { StatusBar } from 'expo-status-bar';
 import { useState } from 'react';
-import { FlatList, View } from 'react-native';
+import { Dimensions, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { TabView, SceneMap } from 'react-native-tab-view';
 
-import AnnouncementItemComponent from '@/components/common/announcementItem';
 import BackHeaderComponent from '@/components/common/backHeader';
-import SpaceItemComponent from '@/components/common/spaceItem';
+import AnnouncementLikeList from '@/components/like/announcementLikeList';
 import LikeSwitchComponent from '@/components/like/likeSwitch';
-import { dummyData } from '@/constants/dummyData/announcementList';
-import { SpacedummyData } from '@/constants/dummyData/spaceList';
-import { useGetLikedAnnouncementLists, useGetLikedSpaceLists } from '@/hooks/guest/guest';
-import { AnnouncementItem } from '@/types/announcement';
-import { SpaceItem } from '@/types/space';
+import SpaceLikeList from '@/components/like/spaceLikeList';
 
-export default function Like() {
-  const spaceData = SpacedummyData;
-  const announcementData = dummyData;
+const renderScene = SceneMap({
+  space: SpaceLikeList,
+  notice: AnnouncementLikeList,
+});
 
-  // const {
-  //   data: spaceData,
-  //   fetchNextPage: fetchSpaceNextPage,
-  //   hasNextPage: hasSpaceNextPage,
-  // } = useGetLikedSpaceLists();
+export default function LikeListScreen() {
+  const [index, setIndex] = useState(0);
 
-  // const {
-  //   data: announcementData,
-  //   fetchNextPage: fetchAnnouncementNextPage,
-  //   hasNextPage: hasAnnouncementNextPage,
-  // } = useGetLikedAnnouncementLists();
-
-  const [currentType, setCurrentType] = useState<'SPACE' | 'ANNOUNCEMENT'>('SPACE');
-
-  const handleType = () => {
-    if (currentType === 'SPACE') {
-      setCurrentType('ANNOUNCEMENT');
-    } else {
-      setCurrentType('SPACE');
-    }
-  };
+  const [routes] = useState([
+    { key: 'space', title: '공간 좋아요' },
+    { key: 'notice', title: '공고 좋아요' },
+  ]);
 
   return (
     <SafeAreaView className="flex-1 bg-white">
+      <StatusBar style="dark" />
       <BackHeaderComponent style="WHITE" hasSafeArea={false}>
-        <LikeSwitchComponent currentType={currentType} handleType={handleType} />
+        <LikeSwitchComponent index={index} setIndex={setIndex} />
       </BackHeaderComponent>
 
-      <FlatList<SpaceItem | AnnouncementItem>
-        contentContainerStyle={{ paddingBottom: 64, paddingTop: 24 }}
-        // data={
-        //   currentType === 'SPACE'
-        //     ? spaceData?.pages.flatMap((page) => page.content)
-        //     : announcementData?.pages.flatMap((page) => page.content)
-        // }
-        data={currentType === 'SPACE' ? spaceData : announcementData}
-        renderItem={({ item }) =>
-          currentType === 'SPACE' ? (
-            <SpaceItemComponent key={item.id} data={item as SpaceItem} />
-          ) : (
-            <AnnouncementItemComponent key={item.id} data={item as AnnouncementItem} />
-          )
-        }
-        ItemSeparatorComponent={() => <View className="h-[16px]" />}
-        onEndReachedThreshold={0.5}
-        // onEndReached={() => {
-        //   if (currentType === 'SPACE') {
-        //     if (hasSpaceNextPage) {
-        //       fetchSpaceNextPage();
-        //     }
-        //   } else {
-        //     if (hasAnnouncementNextPage) {
-        //       fetchAnnouncementNextPage();
-        //     }
-        //   }
-        // }}
+      <View className="h-[24px]" />
+
+      <TabView
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        onIndexChange={setIndex}
+        initialLayout={{ width: Dimensions.get('screen').width }}
+        swipeEnabled={false}
+        renderTabBar={() => null}
       />
     </SafeAreaView>
   );

--- a/components/like/announcementLikeList.tsx
+++ b/components/like/announcementLikeList.tsx
@@ -1,0 +1,67 @@
+import ContentLoader, { Rect } from 'react-content-loader/native';
+import { Dimensions, FlatList, Text, View } from 'react-native';
+
+import { useGetLikedAnnouncementLists } from '@/hooks/guest/guest';
+
+import AnnouncementItemComponent from '../announcement/item/announcementItem';
+
+export default function AnnouncementLikeList() {
+  const { data, isLoading, fetchNextPage, hasNextPage, isError } = useGetLikedAnnouncementLists();
+  const likedAnnouncementData = data?.pages.flatMap((page) => page.content) ?? [];
+
+  if (isError) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text className="BODY1 text-red">잘못된 요청입니다!</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      contentContainerStyle={{ flexGrow: 1, paddingBottom: 64 }}
+      data={isLoading ? Array.from({ length: 3 }).map(() => null) : likedAnnouncementData}
+      keyExtractor={(item, index) => (item ? String(item.id) : `skeleton-${index}`)}
+      renderItem={({ item, index }) =>
+        item ? (
+          <AnnouncementItemComponent key={item.id} data={item} />
+        ) : (
+          <AnnouncementSkeletonItem key={index} />
+        )
+      }
+      ListEmptyComponent={() => (
+        <View className="flex-1 justify-center items-center">
+          <Text className="BODY1 text-medium_gray">좋아요한 공고가 없어요!</Text>
+        </View>
+      )}
+      ItemSeparatorComponent={() => <View className="h-[16px]" />}
+      onEndReachedThreshold={0.5}
+      onEndReached={() => {
+        if (hasNextPage) {
+          fetchNextPage();
+        }
+      }}
+    />
+  );
+}
+
+const AnnouncementSkeletonItem = () => {
+  return (
+    <View className="border border-stroke rounded-lg mx-[20px] bg-white">
+      <ContentLoader
+        speed={2}
+        width={Dimensions.get('screen').width - 40}
+        height={134}
+        backgroundColor="#ecebeb"
+        foregroundColor="#f3f3f3"
+      >
+        {/* 주소 */}
+        <Rect x="16" y="16" rx="4" ry="4" width="120" height="20" />
+        {/* 이름 */}
+        <Rect x="16" y="38" rx="4" ry="4" width="260" height="56" />
+        {/* 사이즈 */}
+        <Rect x="16" y="104" rx="4" ry="4" width="300" height="18" />
+      </ContentLoader>
+    </View>
+  );
+};

--- a/components/like/likeSwitch.tsx
+++ b/components/like/likeSwitch.tsx
@@ -2,11 +2,11 @@ import { useRef, useState } from 'react';
 import { Animated, Dimensions, Pressable, Text } from 'react-native';
 
 interface LikeSwitchComponentProps {
-  currentType: 'SPACE' | 'ANNOUNCEMENT';
-  handleType: () => void;
+  index: number;
+  setIndex: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const LikeSwitchComponent: React.FC<LikeSwitchComponentProps> = ({ currentType, handleType }) => {
+export default function LikeSwitchComponent({ index, setIndex }: LikeSwitchComponentProps) {
   const width = Dimensions.get('screen').width;
   const translateX = useRef(new Animated.Value(0)).current;
 
@@ -18,10 +18,11 @@ const LikeSwitchComponent: React.FC<LikeSwitchComponentProps> = ({ currentType, 
   };
 
   const slideAnimation = () => {
-    handleType();
+    const newIndex = index === 0 ? 1 : 0; // 새 index 계산
+    setIndex(newIndex);
 
     Animated.timing(translateX, {
-      toValue: currentType === 'ANNOUNCEMENT' ? 0 : 69,
+      toValue: newIndex === 0 ? 0 : 69, // 새 index 기준
       duration: 200,
       useNativeDriver: true,
     }).start();
@@ -33,7 +34,7 @@ const LikeSwitchComponent: React.FC<LikeSwitchComponentProps> = ({ currentType, 
       onLayout={handleLayout}
       style={{ left: (width - switchWidth) / 2 }}
       className={`absolute top-[-24px] flex flex-row items-center rounded-full bg-black p-[3px] ${
-        currentType === 'SPACE' ? 'text-black' : 'text-white'
+        index === 0 ? 'text-black' : 'text-white'
       }`}
     >
       <Animated.View
@@ -43,17 +44,15 @@ const LikeSwitchComponent: React.FC<LikeSwitchComponentProps> = ({ currentType, 
         className="absolute left-[4px] top-[3px] h-full w-1/2 rounded-full bg-white"
       />
       <Text
-        className={`BTN1 px-[11px] py-[10.5px] text-center ${currentType === 'SPACE' ? 'text-black' : 'text-white'}`}
+        className={`BTN1 px-[11px] py-[10.5px] text-center ${index === 0 ? 'text-black' : 'text-white'}`}
       >
         찜한공간
       </Text>
       <Text
-        className={`BTN1 px-[11px] py-[10.5px] text-center ${currentType === 'ANNOUNCEMENT' ? 'text-black' : 'text-white'}`}
+        className={`BTN1 px-[11px] py-[10.5px] text-center ${index === 1 ? 'text-black' : 'text-white'}`}
       >
         찜한공고
       </Text>
     </Pressable>
   );
-};
-
-export default LikeSwitchComponent;
+}

--- a/components/like/spaceLikeList.tsx
+++ b/components/like/spaceLikeList.tsx
@@ -1,0 +1,83 @@
+import ContentLoader, { Rect } from 'react-content-loader/native';
+import { Dimensions, FlatList, Text, View } from 'react-native';
+
+import { useGetLikedSpaceLists } from '@/hooks/guest/guest';
+
+import SpaceItemComponent from '../space/item/spaceItem';
+
+export default function SpaceLikeList() {
+  const { data, isLoading, fetchNextPage, hasNextPage, isError } = useGetLikedSpaceLists();
+  const likedSpaceData = data?.pages.flatMap((page) => page.content) || [];
+
+  if (isError) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Text className="BODY1 text-red">잘못된 요청입니다!</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      contentContainerStyle={{ flexGrow: 1, paddingBottom: 64 }}
+      data={isLoading ? Array.from({ length: 3 }).map(() => null) : likedSpaceData}
+      keyExtractor={(item, index) => (item ? String(item.id) : `skeleton-${index}`)}
+      renderItem={({ item, index }) =>
+        item ? <SpaceItemComponent key={item.id} data={item} /> : <SpaceSkeletonItem key={index} />
+      }
+      ListEmptyComponent={() => (
+        <View className="flex-1 justify-center items-center">
+          <Text className="BODY1 text-medium_gray">좋아요한 공간이 없어요!</Text>
+        </View>
+      )}
+      ItemSeparatorComponent={() => <View className="h-[16px]" />}
+      onEndReached={() => {
+        if (hasNextPage) {
+          fetchNextPage();
+        }
+      }}
+    />
+  );
+}
+
+const SpaceSkeletonItem = () => {
+  return (
+    <View className="border border-stroke rounded-lg mx-[20px] bg-white">
+      <ContentLoader
+        speed={2}
+        width={Dimensions.get('screen').width - 40}
+        height={336}
+        backgroundColor="#ecebeb"
+        foregroundColor="#f3f3f3"
+      >
+        {/* 상단 이미지 */}
+        <Rect x="0" y="0" rx="8" ry="8" width={Dimensions.get('screen').width - 40} height="188" />
+
+        {/* 주소 */}
+        <Rect x="16" y="196" rx="4" ry="4" width="120" height="20" />
+        {/* 이름 */}
+        <Rect x="16" y="218" rx="4" ry="4" width="180" height="28" />
+        {/* 사이즈 */}
+        <Rect x="16" y="250" rx="4" ry="4" width="60" height="18" />
+
+        {/* 가격 영역 */}
+        <Rect
+          x={Dimensions.get('screen').width - 40 - 100}
+          y="270"
+          rx="4"
+          ry="4"
+          width="80"
+          height="20"
+        />
+        <Rect
+          x={Dimensions.get('screen').width - 40 - 140}
+          y="292"
+          rx="4"
+          ry="4"
+          width="120"
+          height="28"
+        />
+      </ContentLoader>
+    </View>
+  );
+};

--- a/hooks/guest/guest.ts
+++ b/hooks/guest/guest.ts
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 
 import {
@@ -24,7 +24,7 @@ export const useUpdateGuestInfo = (refetch: any) => {
 
 // 공간 좋아요 목록 조회
 export const useGetLikedSpaceLists = () => {
-  return useSuspenseInfiniteQuery({
+  return useInfiniteQuery({
     queryKey: [`/guest/like/space`],
     queryFn: async ({ pageParam }) => {
       const response = getLikedSpaceLists(pageParam, 5);
@@ -41,7 +41,7 @@ export const useGetLikedSpaceLists = () => {
 
 // 공고 좋아요 목록 조회
 export const useGetLikedAnnouncementLists = () => {
-  return useSuspenseInfiniteQuery({
+  return useInfiniteQuery({
     queryKey: [`/guest/like/announcement`],
     queryFn: async ({ pageParam }) => {
       const response = getLikedAnnounceMentLists(pageParam, 5);

--- a/hooks/like/like.ts
+++ b/hooks/like/like.ts
@@ -8,13 +8,18 @@ export const useToggleSpaceLike = (id: number) => {
 
   return useMutation({
     mutationFn: () => toggleLikeSpace(id),
-    onSuccess: () => {
+    onSuccess: async () => {
       // 공간 목록 조회
-      queryClient.invalidateQueries({ queryKey: [`/space/list`] });
+      await queryClient.refetchQueries({
+        queryKey: [`/space/list`],
+        exact: false,
+      });
       // 공간 상세 조회
-      queryClient.invalidateQueries({ queryKey: [`/space/${id}`, id] });
+      await queryClient.invalidateQueries({ queryKey: [`/space/${id}`, id] });
       // 좋아요 공간 목록
-      queryClient.invalidateQueries({ queryKey: [`/guest/like/space`] });
+      await queryClient.invalidateQueries({ queryKey: [`/guest/like/space`] });
+      // 공간 검색
+      await queryClient.invalidateQueries({ queryKey: [`/space/list/search`] });
     },
   });
 };
@@ -25,13 +30,18 @@ export const useToggleAnnouncementLike = (id: number) => {
 
   return useMutation({
     mutationFn: () => toggleLikeAnnouncement(id),
-    onSuccess: () => {
-      // 공간 목록 조회
-      queryClient.invalidateQueries({ queryKey: [`/announcement/list`] });
-      // 공간 상세 조회
-      queryClient.invalidateQueries({ queryKey: [`/announcement/${id}`, id] });
-      // 좋아요 공간 목록
-      queryClient.invalidateQueries({ queryKey: [`/guest/like/announcement`] });
+    onSuccess: async () => {
+      // 공고 목록 조회
+      await queryClient.refetchQueries({
+        queryKey: [`/announcement/list`],
+        exact: false,
+      });
+      // 공고 상세 조회
+      await queryClient.invalidateQueries({ queryKey: [`/announcement/${id}`, id] });
+      // 좋아요 공고 목록
+      await queryClient.invalidateQueries({ queryKey: [`/guest/like/announcement`] });
+      // 공고 검색
+      await queryClient.invalidateQueries({ queryKey: [`/announcement/list/search`] });
     },
   });
 };

--- a/server/guest/guest.ts
+++ b/server/guest/guest.ts
@@ -10,7 +10,7 @@ import {
 
 // 게스트 정보 수정
 export const updateGuestInfo = async (data: UpdateInfoRequest): Promise<UpdateInfoResponse> => {
-  const response = await PostAxiosInstance<UpdateInfoResponse>(`/guest/update`, data);
+  const response = await PostAxiosInstance<UpdateInfoResponse>(`/v1/guest/update`, data);
 
   return response.data;
 };
@@ -20,7 +20,7 @@ export const getLikedSpaceLists = async (
   page?: number,
   size?: number,
 ): Promise<GetLikedSpaceListsResponse> => {
-  const response = await GetAxiosInstance<GetLikedSpaceListsResponse>(`/guest/like/space`, {
+  const response = await GetAxiosInstance<GetLikedSpaceListsResponse>(`/v1/guest/like/space`, {
     params: {
       page: page,
       size: size,
@@ -36,7 +36,7 @@ export const getLikedAnnounceMentLists = async (
   size?: number,
 ): Promise<GetLikedAnnouncementListsResponse> => {
   const response = await GetAxiosInstance<GetLikedAnnouncementListsResponse>(
-    `/guest/like/announcement`,
+    `/v1/guest/like/announcement`,
     {
       params: {
         page: page,
@@ -50,7 +50,7 @@ export const getLikedAnnounceMentLists = async (
 
 // 게스트 정보 조회
 export const getGuestInfo = async (): Promise<GetGuestInfoResponse> => {
-  const response = await GetAxiosInstance<GetGuestInfoResponse>(`/guest/info`);
+  const response = await GetAxiosInstance<GetGuestInfoResponse>(`/v1/guest/info`);
 
   return response.data;
 };

--- a/server/like/like.ts
+++ b/server/like/like.ts
@@ -4,14 +4,14 @@ import { ToggleLikeResponse } from './response';
 
 // 공간 좋아요
 export const toggleLikeSpace = async (id: number): Promise<ToggleLikeResponse> => {
-  const response = await PostAxiosInstance<ToggleLikeResponse>(`/like/like/space/${id}`);
+  const response = await PostAxiosInstance<ToggleLikeResponse>(`/v1/like/like/space/${id}`);
 
   return response.data;
 };
 
 // 공고 좋아요
 export const toggleLikeAnnouncement = async (id: number): Promise<ToggleLikeResponse> => {
-  const response = await PostAxiosInstance<ToggleLikeResponse>(`/like/like/announcement/${id}`);
+  const response = await PostAxiosInstance<ToggleLikeResponse>(`/v1/like/like/announcement/${id}`);
 
   return response.data;
 };


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[DICE-27] 공간 및 공고 좋아요 목록 스크린 수정

## 📌 반영 브랜치
DICE-27 -> dev

## 📋 내용
### 💻 찜 목록 스크린
- [x] 기존에 타입으로 구분했던 찜 목록 스크린을 TabView를 활용하여 구분하였습니다.

---

### 💻 찜한 공간 목록 스크린
- [x] 이전에 적용했던 공간 아이템의 Skeleton UI를 적용했습니다.
<img src="https://github.com/user-attachments/assets/d8ea136a-b654-4a74-8723-31575d84eb66" width="250" />
<img src="https://github.com/user-attachments/assets/5674aa95-7367-4594-936c-a2d9da1ea84e" width="250" />

---

### 💻 찜한 공고 목록 스크린
- [x] 이전에 적용했던 공고 아이템의 Skeleton UI를 적용했습니다.
<img src="https://github.com/user-attachments/assets/a725b993-a9a2-4264-9d83-99c49fe4e0ac" width="250" />
<img src="https://github.com/user-attachments/assets/eab927ea-5815-45ca-be19-c4af2be8530d" width="250" />


## 🚨 유의 사항
- [x] 없음

[DICE-27]: https://devjjhyeok13.atlassian.net/browse/DICE-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a tabbed Likes screen to switch between liked spaces and announcements.
  - Added infinite scrolling, loading skeletons, and clear empty/error states for both lists.
  - Improved UI polish with a dedicated switch control and layout/status bar adjustments.

- Refactor
  - Updated data fetching to a non-suspense infinite loading approach for greater stability.
  - Enhanced like-toggle behavior to more reliably refresh lists, detail views, and search results.

- Chores
  - Migrated guest and like API endpoints to versioned paths (v1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->