### PR TITLE
[DICE-29] 나의 정보 스크린 수정

### DIFF
--- a/app/(tabs)/myPage.tsx
+++ b/app/(tabs)/myPage.tsx
@@ -1,38 +1,22 @@
-import { Dimensions, ScrollView, View } from 'react-native';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import CoverViewComponent from '@/components/common/coverView';
 import BrandInfoComponent from '@/components/myPage/brandInfo';
 import MenuContainer from '@/components/myPage/menuContainer';
-import { useGetMyBrandInfo } from '@/hooks/brand/brand';
 
 export default function MyPage() {
   const { top } = useSafeAreaInsets();
 
-  // const { data } = useGetMyBrandInfo();
-
-  const data = [
-    {
-      id: 1,
-      name: '이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름',
-      description:
-        '안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요',
-      logoUrl: '',
-      // imageUrls: ['https://picsum.photos/250/250'],
-      imageUrls: [],
-      homepageUrl: '',
-    },
-  ];
-
   return (
     <View className="flex-1 bg-white">
       <View style={{ height: top, backgroundColor: '#000000' }} />
-      <CoverViewComponent height={500} top={-100} />
 
+      <CoverViewComponent height={500} top={-100} />
       <ScrollView
         contentContainerStyle={{ flexGrow: 1, backgroundColor: '#FFFFFF', paddingBottom: 64 }}
       >
-        <BrandInfoComponent data={data} />
+        <BrandInfoComponent />
         <MenuContainer />
       </ScrollView>
     </View>

--- a/app/space/reservation/complete.tsx
+++ b/app/space/reservation/complete.tsx
@@ -1,9 +1,9 @@
+import { CommonActions, useNavigation } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import ReservationInfoComponent from '@/components/space/reservationInfo';
-import { CommonActions, useNavigation } from '@react-navigation/native';
 
 export default function ReservationComplete() {
   const navigation = useNavigation();

--- a/components/myPage/brandInfo.tsx
+++ b/components/myPage/brandInfo.tsx
@@ -1,60 +1,92 @@
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
-import { FlatList, Pressable, Text } from 'react-native';
+import ContentLoader, { Rect } from 'react-content-loader/native';
+import { Dimensions, FlatList, Text, TouchableOpacity, View } from 'react-native';
 
 import EditIcon from '@/assets/icons/myPage/edit.svg';
-import { BrandInfo } from '@/server/brand/response';
+import { useGetMyBrandInfo } from '@/hooks/brand/brand';
 
-interface BrandInfoComponentProps {
-  data: BrandInfo[];
-}
-
-const BrandInfoComponent: React.FC<BrandInfoComponentProps> = ({ data }) => {
+export default function BrandInfoComponent() {
   const router = useRouter();
 
-  return (
-    <Pressable
-      onPress={() => (data.length !== 0 ? undefined : router.push('/myPage/management/brand'))}
-      className="bg-black gap-y-[16px] pt-[4px] pl-[20px] pb-[16px]"
-    >
-      <Pressable
+  const { data, isFetching } = useGetMyBrandInfo();
+
+  return isFetching ? (
+    <BrandInfoSkeleton />
+  ) : (
+    <View className="bg-black pt-[4px] pl-[20px] pb-[16px]">
+      <TouchableOpacity
         onPress={() => router.push('/myPage/management/brand')}
         className="p-[12px] mb-[4px] mr-[6px] self-end"
       >
         <EditIcon />
-      </Pressable>
+      </TouchableOpacity>
 
-      <Text numberOfLines={2} ellipsizeMode="tail" className="H1 text-white mr-[20px]">
-        {data.length !== 0 ? data[0].name : '브랜드 프로필을 작성해주세요'}
-      </Text>
-      <Text numberOfLines={2} ellipsizeMode="tail" className="BODY2 text-light_gray mr-[20px]">
-        {data.length !== 0
-          ? data[0].description
-          : '팝업 공간을 대여해주는 호스트와 신뢰할 수 있는 거래를 위해 브랜드를 1~2문장으로 짧게 설명해주세요'}
-      </Text>
+      <View className="gap-y-[16px]">
+        <Text numberOfLines={2} ellipsizeMode="tail" className="H1 text-white mr-[20px]">
+          {data && data.length !== 0 ? data[0].name : '브랜드 프로필을 작성해주세요'}
+        </Text>
+        <Text numberOfLines={2} ellipsizeMode="tail" className="BODY2 text-light_gray mr-[20px]">
+          {data && data.length !== 0
+            ? data[0].description
+            : '팝업 공간을 대여해주는 호스트와 신뢰할 수 있는 거래를 위해 브랜드를 1~2문장으로 짧게 설명해주세요'}
+        </Text>
 
-      <FlatList
-        data={
-          data.length !== 0 && data[0].imageUrls.length !== 0
-            ? data[0].imageUrls
-            : Array.from({ length: 5 }, (_, i) => `item${i}`)
-        }
-        contentContainerStyle={{ columnGap: 4, paddingRight: 20 }}
-        showsHorizontalScrollIndicator={false}
-        renderItem={({ item }) => (
-          <Image
-            source={
-              data.length !== 0 && data[0].imageUrls.length !== 0
-                ? { uri: item }
-                : require('@/assets/image/emptyImage.png')
-            }
-            style={{ width: 80, height: 80, borderRadius: 12 }}
-          />
-        )}
-        horizontal={true}
-      />
-    </Pressable>
+        <FlatList
+          data={
+            data && data.length !== 0 && data[0].imageUrls.length !== 0
+              ? data[0].imageUrls
+              : Array.from({ length: 5 }, (_, i) => `item${i}`)
+          }
+          contentContainerStyle={{ columnGap: 4, paddingRight: 20 }}
+          showsHorizontalScrollIndicator={false}
+          renderItem={({ item }) => (
+            <Image
+              source={
+                data && data.length !== 0 && data[0].imageUrls.length !== 0
+                  ? { uri: item }
+                  : require('@/assets/image/emptyImage.png')
+              }
+              style={{ width: 80, height: 80, borderRadius: 12 }}
+            />
+          )}
+          horizontal={true}
+        />
+      </View>
+    </View>
+  );
+}
+
+const BrandInfoSkeleton = () => {
+  return (
+    <View className="bg-black">
+      <ContentLoader
+        speed={2}
+        width={Dimensions.get('screen').width}
+        height={257}
+        backgroundColor="#ecebeb"
+        foregroundColor="#f3f3f3"
+      >
+        {/* 브랜드 이름 */}
+        <Rect x="20" y="56" rx="4" ry="4" width="120" height="29" />
+
+        {/* 브랜드 소개 */}
+        <Rect
+          x="20"
+          y="101"
+          rx="4"
+          ry="4"
+          width={Dimensions.get('screen').width - 40}
+          height="44"
+        />
+
+        {/* 이미지 */}
+        <Rect x="20" y="161" rx="12" ry="12" width="80" height="80" />
+        <Rect x="104" y="161" rx="12" ry="12" width="80" height="80" />
+        <Rect x="188" y="161" rx="12" ry="12" width="80" height="80" />
+        <Rect x="272" y="161" rx="12" ry="12" width="80" height="80" />
+        <Rect x="356" y="161" rx="12" ry="12" width="80" height="80" />
+      </ContentLoader>
+    </View>
   );
 };
-
-export default BrandInfoComponent;

--- a/components/myPage/menuContainer.tsx
+++ b/components/myPage/menuContainer.tsx
@@ -1,51 +1,49 @@
 import { useRouter } from 'expo-router';
-import { Pressable, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { useLogout } from '@/hooks/auth/auth';
+
+import OpacityPressable from '../common/opacityPressable';
 
 const MenuContainer: React.FC = () => {
   const router = useRouter();
 
   const { mutateAsync: logout } = useLogout();
 
+  const menuGroups: {
+    label: string;
+    onPress: () => void;
+  }[][] = [
+    [
+      { label: '찜한 목록', onPress: () => router.push('/(topTabs)/like') },
+      { label: '쪽지함', onPress: () => router.push('/(topTabs)/chat') },
+    ],
+    [
+      { label: '회원 정보 관리', onPress: () => router.push('/myPage/management/guest') },
+      { label: '이용 약관', onPress: () => router.push('/myPage/(terms)/terms-of-service') },
+      { label: '개인정보 처리방침', onPress: () => router.push('/myPage/(terms)/privacy-policy') },
+    ],
+    [{ label: '로그아웃', onPress: () => logout() }],
+    [{ label: '탈퇴하기', onPress: () => router.push('/myPage/withdraw') }],
+  ];
+
   return (
     <View className="px-[20px] py-[24px]">
-      <Pressable onPress={() => router.push('/(topTabs)/like')} className="py-[12px]">
-        <Text className="SUB3 text-deep_gray">찜한 목록</Text>
-      </Pressable>
-      <Pressable onPress={() => router.push('/(topTabs)/chat')} className="py-[12px]">
-        <Text className="SUB3 text-deep_gray">쪽지함</Text>
-      </Pressable>
+      {menuGroups.map((group, i) => (
+        <View key={i}>
+          {group.map(({ label, onPress }) => (
+            <OpacityPressable key={label} onPress={onPress} className="py-[12px]">
+              <Text className="SUB3 text-deep_gray">{label}</Text>
+            </OpacityPressable>
+          ))}
 
-      <View className="h-[1px] bg-stroke my-[24px]" />
-
-      <Pressable onPress={() => router.push('/myPage/management/guest')} className="py-[12px]">
-        <Text className="SUB3 text-deep_gray">회원 정보 관리</Text>
-      </Pressable>
-      <Pressable
-        onPress={() => router.push('/myPage/(terms)/terms-of-service')}
-        className="py-[12px]"
-      >
-        <Text className="SUB3 text-deep_gray">이용 약관</Text>
-      </Pressable>
-      <Pressable
-        onPress={() => router.push('/myPage/(terms)/privacy-policy')}
-        className="py-[12px]"
-      >
-        <Text className="SUB3 text-deep_gray">개인정보 처리방침</Text>
-      </Pressable>
-
-      <View className="h-[1px] bg-stroke my-[24px]" />
-
-      <Pressable onPress={() => logout()} className="py-[12px]">
-        <Text className="SUB3 text-deep_gray">로그아웃</Text>
-      </Pressable>
-
-      <View className="h-[8px] bg-back_gray my-[24px] mx-[-20px]" />
-
-      <Pressable onPress={() => router.push('/myPage/withdraw')} className="py-[12px]">
-        <Text className="SUB3 text-deep_gray">탈퇴하기</Text>
-      </Pressable>
+          {i === 0 || i === 1 ? (
+            <View className="h-[1px] bg-stroke my-[24px]" />
+          ) : i === 2 ? (
+            <View className="h-[8px] bg-back_gray my-[24px] mx-[-20px]" />
+          ) : null}
+        </View>
+      ))}
     </View>
   );
 };


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[DICE-29] 나의 정보 스크린 수정

## 📌 반영 브랜치
DICE-29 -> dev

## 📋 내용
### 💻 나의 정보 스크린
- [x] 나의 정보 스크린에 대해서 리팩토링을 진행했습니다.
- [x] 이미지의 경우 API 데이터의 누락으로 따로 없습니다.

## 🚨 유의 사항
- [x] 없음

[DICE-29]: https://devjjhyeok13.atlassian.net/browse/DICE-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Brand info now loads dynamically and displays a skeleton while fetching.
  - Menu is grouped with consistent tap feedback and clearer visual separators.

- Refactor
  - Simplified imports and navigation setup without changing behavior.
  - Removed hardcoded data and props; streamlined brand info rendering.
  - Consolidated menu rendering using a data-driven structure for scalability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->